### PR TITLE
Use glibc package maintainer's signing key instead of allowing untrusted packages

### DIFF
--- a/nomad/Dockerfile
+++ b/nomad/Dockerfile
@@ -7,6 +7,8 @@ ENV NOMAD_ARCHIVE_SHA256SUM 710ff3515bc449bc2a06652464f4af55f1b76f63c77a9048bc30
 
 ENV GLIBC_VERSION 2.23-r1
 ENV GLIBC_RELEASE_URL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}
+ENV GLIBC_KEY_URL https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/andyshinn.rsa.pub
+ENV GLIBC_KEY_PATH /etc/apk/keys/andyshinn.rsa.pub
 
 RUN apk add --no-cache  \
     curl \
@@ -15,6 +17,11 @@ RUN apk add --no-cache  \
     libgcc
 
 RUN curl \
+    --silent \
+    --show-error \
+    --location ${GLIBC_KEY_URL} \
+    --output ${GLIBC_KEY_PATH} \
+  && curl \
     --silent \
     --show-error \
     --location "${GLIBC_RELEASE_URL}/glibc-${GLIBC_VERSION}.apk" \
@@ -27,7 +34,8 @@ RUN curl \
   && apk add --no-cache --allow-untrusted \
     /tmp/glibc-${GLIBC_VERSION}.apk \
     /tmp/glibc-bin-${GLIBC_VERSION}.apk \
-  && rm -rf /tmp/glibc*
+  && rm -rf /tmp/glibc* \
+  && rm ${GLIBC_KEY_PATH}
 
 RUN curl \
     --silent \

--- a/sumo-livetail/Dockerfile
+++ b/sumo-livetail/Dockerfile
@@ -5,6 +5,8 @@ ENV LIVETAIL_VERSION 1.0
 ENV LIVETAIL_RELEASE_URL https://github.com/SumoLogic/livetail-cli/releases/download/v${LIVETAIL_VERSION}/livetail_linux.zip
 ENV GLIBC_VERSION 2.23-r1
 ENV GLIBC_RELEASE_URL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}
+ENV GLIBC_KEY_URL https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/andyshinn.rsa.pub
+ENV GLIBC_KEY_PATH /etc/apk/keys/andyshinn.rsa.pub
 
 RUN apk add --no-cache \
     ca-certificates \
@@ -15,6 +17,11 @@ RUN apk add --no-cache \
 RUN curl \
     --silent \
     --show-error \
+    --location ${GLIBC_KEY_URL} \
+    --output ${GLIBC_KEY_PATH} \
+  && curl \
+    --silent \
+    --show-error \
     --location "${GLIBC_RELEASE_URL}/glibc-${GLIBC_VERSION}.apk" \
     --output /tmp/glibc-${GLIBC_VERSION}.apk \
   && curl \
@@ -22,10 +29,11 @@ RUN curl \
     --show-error \
     --location "${GLIBC_RELEASE_URL}/glibc-bin-${GLIBC_VERSION}.apk" \
     --output /tmp/glibc-bin-${GLIBC_VERSION}.apk \
-  && apk add --no-cache --allow-untrusted \
+  && apk add --no-cache \
     /tmp/glibc-${GLIBC_VERSION}.apk \
     /tmp/glibc-bin-${GLIBC_VERSION}.apk \
-  && rm -rf /tmp/glibc*
+  && rm -rf /tmp/glibc* \
+  && rm ${GLIBC_KEY_PATH}
 
 RUN curl \
     --silent \

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -5,6 +5,8 @@ ENV TERRAFORM_VERSION 0.6.15
 ENV TERRAFORM_RELEASE_URL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ENV GLIBC_VERSION 2.23-r1
 ENV GLIBC_RELEASE_URL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}
+ENV GLIBC_KEY_URL https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/andyshinn.rsa.pub
+ENV GLIBC_KEY_PATH /etc/apk/keys/andyshinn.rsa.pub
 
 RUN apk add --no-cache \
     ca-certificates \
@@ -13,6 +15,11 @@ RUN apk add --no-cache \
     libgcc
 
 RUN curl \
+    --silent \
+    --show-error \
+    --location ${GLIBC_KEY_URL} \
+    --output ${GLIBC_KEY_PATH} \
+  && curl \
     --silent \
     --show-error \
     --location "${GLIBC_RELEASE_URL}/glibc-${GLIBC_VERSION}.apk" \
@@ -25,7 +32,8 @@ RUN curl \
   && apk add --no-cache --allow-untrusted \
     /tmp/glibc-${GLIBC_VERSION}.apk \
     /tmp/glibc-bin-${GLIBC_VERSION}.apk \
-  && rm -rf /tmp/glibc*
+  && rm -rf /tmp/glibc* \
+  && rm ${GLIBC_KEY_PATH}
 
 RUN curl \
   --silent \
@@ -37,3 +45,4 @@ RUN curl \
   && rm -rf /tmp/terraform_${TERRAFORM_VERSION}.zip /tmp/terraform
 
 ENTRYPOINT ["/usr/local/bin/terraform"]
+


### PR DESCRIPTION
This PR resolves #6.